### PR TITLE
Add Python 3.14 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: Continous Integration
 
-on: [push, pull_request]
+on: 
+  push: 
+    branches: ["main"]
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14.0-rc.2"]
 
     steps:
       - name: Checkout
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14.0-rc.2"]
         os: [ubuntu, windows, macos]
 
     steps:


### PR DESCRIPTION
# Changes
- Add Python 3.14 to CI
- Running CI on pushes just to main branch


For now, we are using release candidate.  Before merge, and when Python 3.14 is released:
- [ ] Change Python version in the matrix to `"3.14"`